### PR TITLE
Add appropriate project type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Collision's adapter for Symfony applications. Error Reporting for console/command-line PHP applications.",
     "keywords": ["symfony", "bundle", "console", "command-line", "php", "cli", "error", "handling", "collision", "laravel-zero"],
     "license": "MIT",
+    "type": "symfony-bundle",
     "authors": [
         {
             "name": "Nuno Maduro",


### PR DESCRIPTION
Adding the project type "symfony-bundle" will allow the flex-plugin to auto-register the bundle. This also means that manually adding the bundle to `config/bundles.php` should no longer be necessary. If you want I can also update the README accordingly.